### PR TITLE
Fixed channel status JSON mapping

### DIFF
--- a/addons/binding/org.openhab.binding.supla/src/main/java/org/openhab/binding/supla/internal/commands/SwitchChannelCommandExecutor.java
+++ b/addons/binding/org.openhab.binding.supla/src/main/java/org/openhab/binding/supla/internal/commands/SwitchChannelCommandExecutor.java
@@ -65,6 +65,6 @@ class SwitchChannelCommandExecutor implements CommandExecutor {
     }
 
     private OnOffType getState(SuplaChannelStatus status) {
-        return status.isEnabled() ? ON : OFF;
+        return status.isOn() ? ON : OFF;
     }
 }

--- a/addons/binding/org.openhab.binding.supla/src/main/java/org/openhab/binding/supla/internal/supla/api/SuplaChannelManager.java
+++ b/addons/binding/org.openhab.binding.supla/src/main/java/org/openhab/binding/supla/internal/supla/api/SuplaChannelManager.java
@@ -17,6 +17,8 @@ import org.openhab.binding.supla.internal.http.Response;
 import org.openhab.binding.supla.internal.mappers.JsonMapper;
 import org.openhab.binding.supla.internal.supla.entities.SuplaChannel;
 import org.openhab.binding.supla.internal.supla.entities.SuplaChannelStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 import java.util.Optional;
@@ -30,6 +32,8 @@ public final class SuplaChannelManager implements ChannelManager {
     private static final Map<String, String> TURN_ON_PARAMS = ImmutableMap.<String, String>builder().put("action", "turn-on").build();
     private static final Map<String, String> TURN_OFF_PARAMS = ImmutableMap.<String, String>builder().put("action", "turn-off").build();
 
+    private final Logger logger = LoggerFactory.getLogger(SuplaChannelManager.class);
+
     private final HttpExecutor httpExecutor;
     private final JsonMapper jsonMapper;
 
@@ -40,11 +44,13 @@ public final class SuplaChannelManager implements ChannelManager {
 
     @Override
     public boolean turnOn(SuplaChannel channel) {
+        logger.debug("Turning channel {} ON", channel);
         return turn(channel.getId(), TURN_ON_PARAMS).success();
     }
 
     @Override
     public boolean turnOff(SuplaChannel channel) {
+        logger.debug("Turning channel {} OFF", channel);
         return turn(channel.getId(), TURN_OFF_PARAMS).success();
     }
 

--- a/addons/binding/org.openhab.binding.supla/src/main/java/org/openhab/binding/supla/internal/supla/entities/SuplaChannelStatus.java
+++ b/addons/binding/org.openhab.binding.supla/src/main/java/org/openhab/binding/supla/internal/supla/entities/SuplaChannelStatus.java
@@ -14,10 +14,12 @@ package org.openhab.binding.supla.internal.supla.entities;
 public final class SuplaChannelStatus {
     private final boolean connected;
     private final boolean enabled;
+    private final boolean on;
 
-    public SuplaChannelStatus(boolean connected, boolean enabled) {
+    public SuplaChannelStatus(boolean connected, boolean enabled, boolean on) {
         this.connected = connected;
         this.enabled = enabled;
+        this.on = on;
     }
 
     public boolean isConnected() {
@@ -28,11 +30,16 @@ public final class SuplaChannelStatus {
         return enabled;
     }
 
+    public boolean isOn() {
+        return on;
+    }
+
     @Override
     public String toString() {
         return "SuplaChannelStatus{" +
                 "connected=" + connected +
                 ", enabled=" + enabled +
+                ", on=" + on +
                 '}';
     }
 }


### PR DESCRIPTION
SuplaChannelStatus class was missing the 'on' field which holds current switch state. Moreover SwitchChannelCommandExecutor class was using 'enabled' field to determine on/off state which resulted in incorrect switch state ('on' field should be used).